### PR TITLE
Regenerate the sample data via GHAs

### DIFF
--- a/.github/actions/regenerate/action.yml
+++ b/.github/actions/regenerate/action.yml
@@ -1,0 +1,22 @@
+name: "Regenerate sample data"
+description: "Runs the regenerate sample data workflow and commits the result"
+
+runs:
+  using: "composite"
+  steps:
+    - uses: ./.github/actions/setup
+      with:
+        python-version: 3.12
+
+    - name: Verify registry
+      run: |
+        git config --global user.name "$GITHUB_ACTOR"
+        git config --global user.email "$CI_COMMIT_EMAIL"
+
+        make fetch-test-data
+        make registry.txt
+        git diff
+
+        git add data registry.txt
+        git commit -m "Updated sample data"
+        git push

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,6 +39,7 @@ jobs:
 
       - name: Verify registry
         run: |
+          make fetch-test-data
           make registry.txt
           git diff --exit-code
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,6 @@ jobs:
 
       - name: Verify registry
         run: |
-          make fetch-test-data
           make registry.txt
           git diff --exit-code
 

--- a/.github/workflows/pr-comment.yaml
+++ b/.github/workflows/pr-comment.yaml
@@ -1,0 +1,92 @@
+# Run the regeneration when a comment is made on a PR that contains the text "/regenerate".
+# Draws from a very useful blog article: https://grem1.in/post/gha-comment-trigger/
+
+name: PR Comment handling
+on:
+  issue_comment:
+  types:
+    - created
+
+jobs:
+  regenerate:
+    name: Regenerate sample data
+    if: ${{ github.event.issue.pull_request && github.event.comment.body == '/regenerate' }}
+    steps:
+      - name: Put a reaction to the comment
+        run: gh api graphql --silent --raw-field query="mutation AddReaction {addReaction(input:{subjectId:\"$NODE_ID\",content:EYES}){reaction{content}subject{id}}}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_ID: ${{ github.event.comment.node_id }}
+
+      - name: Check if PR is open
+        run: |
+          STATE=$(gh pr view $PR_NUMBER --repo ${{ github.repository }} --json state --jq .state)
+          if [ "$STATE" != "OPEN" ]; then
+            echo "Cannot build for closed PRs"
+            (
+              echo "**${{ github.workflow }}**"
+              echo "Cannot build regenerate the smaple data for a closed PR."
+            ) | \
+            gh pr comment "${PR_NUMBER}" --repo ${{ github.repository }} -F -
+            gh api graphql --silent --raw-field query="mutation AddReaction {addReaction(input:{subjectId:\"$NODE_ID\",content:THUMBS_DOWN}){reaction{content}subject{id}}}"
+            gh api graphql --silent --raw-field query="mutation RemoveReaction {removeReaction(input:{subjectId:\"$NODE_ID\",content:EYES}){reaction{content}subject{id}}}"
+            exit 1
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          NODE_ID: ${{ github.event.comment.node_id }}
+
+      - name: Get PR HEAD Ref
+        id: getRef
+        run: echo "pr_ref=$(gh pr view $PR_NUMBER --repo ${{ github.repository }} --json headRefOid | jq -r '.headRefOid')" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+
+      - name: Checkout source code from Github
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ steps.getRef.outputs.pr_ref }}
+          token: ${{ secrets.PAT }}
+
+      - name: Run the regeneration
+        uses: ./.github/actions/regenerate
+
+      - name: Final Comment
+        run: |
+          gh api graphql --silent --raw-field query="mutation AddReaction {addReaction(input:{subjectId:\"$NODE_ID\",content:THUMBS_UP}){reaction{content}subject{id}}}"
+          gh api graphql --silent --raw-field query="mutation RemoveReaction {removeReaction(input:{subjectId:\"$NODE_ID\",content:EYES}){reaction{content}subject{id}}}"
+          (
+            echo "**${{ github.workflow }}**"
+            echo "The regenerate task is done!"
+            echo
+            echo "You can find the workflow here:"
+            echo "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          ) | \
+          gh pr comment "${PR_NUMBER}" --repo ${{ github.repository }} -F -
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          NODE_ID: ${{ github.event.comment.node_id }}
+
+  notify-job:
+    needs: [regenerate]
+    if: ${{ always() && contains(needs.*.result, 'failure') }}
+    steps:
+      - name: Notify on Failure
+        run: |
+          gh api graphql --silent --raw-field query="mutation AddReaction {addReaction(input:{subjectId:\"$NODE_ID\",content:THUMBS_DOWN}){reaction{content}subject{id}}}"
+          gh api graphql --silent --raw-field query="mutation RemoveReaction {removeReaction(input:{subjectId:\"$NODE_ID\",content:EYES}){reaction{content}subject{id}}}"
+          (
+            echo "**${{ github.workflow }}**"
+            echo "**Something went wrong!**"
+            echo
+            echo "**Details:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          ) | \
+          gh pr comment "${PR_NUMBER}" --repo ${{ github.repository }} -F -
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          NODE_ID: ${{ github.event.comment.node_id }}

--- a/.github/workflows/regenerate-sample-data.yaml
+++ b/.github/workflows/regenerate-sample-data.yaml
@@ -1,0 +1,35 @@
+name: Regenerate sample data
+
+on:
+  workflow_dispatch:
+
+jobs:
+  update-data:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ "ubuntu-latest" ]
+        python-version: [ "3.12"]
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.PAT }}
+      - uses: ./.github/actions/setup
+        with:
+          python-version: 3.12
+
+      - name: Verify registry
+        run: |
+          git config --global user.name "$GITHUB_ACTOR"
+          git config --global user.email "$CI_COMMIT_EMAIL"
+
+          make fetch-test-data
+          make registry.txt
+          git diff
+
+          git add data registry.txt
+          git commit -m "Updated sample data"
+          git push

--- a/.github/workflows/regenerate-sample-data.yaml
+++ b/.github/workflows/regenerate-sample-data.yaml
@@ -5,11 +5,6 @@ on:
 
 jobs:
   update-data:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ "ubuntu-latest" ]
-        python-version: [ "3.12"]
     runs-on: "ubuntu-latest"
     steps:
       - name: Check out repository
@@ -17,19 +12,4 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.PAT }}
-      - uses: ./.github/actions/setup
-        with:
-          python-version: 3.12
-
-      - name: Verify registry
-        run: |
-          git config --global user.name "$GITHUB_ACTOR"
-          git config --global user.email "$CI_COMMIT_EMAIL"
-
-          make fetch-test-data
-          make registry.txt
-          git diff
-
-          git add data registry.txt
-          git commit -m "Updated sample data"
-          git push
+      - uses: ./.github/actions/regenerate

--- a/changelog/7.feature.md
+++ b/changelog/7.feature.md
@@ -1,0 +1,3 @@
+Added an action to regenerate the sample data in Pull Requests.
+
+A comment containing `\regenerate` will trigger the action.


### PR DESCRIPTION
## Description

This makes the sample data generated using GHA the source of truth (see #6). 

This adds two actions (one to manually regenerate the sample data for a given branch and the other will regenerate the sample data when adding a comment to a PR that consists of the text `/regenerate`.

The first action is mostly for testing the action and will be later removed.


## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [x] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`
